### PR TITLE
Composite action#2: Deploy Helm chart to Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Look for for the latest version available on the [Releases](https://github.com/j
     uses: julanu/composite-actions/helm-deploy@latest
     with:
       chart_name: my-chart
-      registry_url:   https://charts.helm.sh/stable
+      registry_url: https://charts.helm.sh/stable
+      registry_name: bitnami
       namespace: testing
       chart_version: 4.1.14
 ```

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-## composite-actions 
+## composite-actions - 
 Repository containing multiple composite Github Actions(multiple declared in a YML which will evaluate to a single Github Action) for CI/CD pipelines.
 <br/>
 
-### Available composite actions:
-- Docker Build & Push Image to DockerHub
-<br/>
+## Usage of available composite actions:
+Look for for the latest version available on the [Releases](https://github.com/julanu/composite-actions/releases) page of this repository and update the actions `@version`.
 
-### Usage:
+
+### 1. Docker Build & Push Image to DockerHub
 ```yaml
   # Login, build and push Docker image to DockerHub
-  - name: Build and Push the image
+  - name: Build and Push Docker
     uses: julanu/composite-actions/docker-build-push@latest
     with:
       registry_user: userID
@@ -20,4 +20,15 @@ Repository containing multiple composite Github Actions(multiple declared in a Y
       dockerfile: ./Dockerfile
       platforms: linux/arm64,linux/amd64
       build_args: -e "token=value"
+```
+### 2. Deploy Helm chart to Kubernetes  
+```yaml
+  # Add Helm repository, update, dry-run and install
+  - name: Helm Deploy to Kubernetes
+    uses: julanu/composite-actions/helm-deploy@latest
+    with:
+      chart_name: my-chart
+      registry_url:   https://charts.helm.sh/stable
+      namespace: testing
+      chart_version: 4.1.14
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ## composite-actions - 
 Repository containing multiple composite Github Actions(multiple declared in a YML which will evaluate to a single Github Action) for CI/CD pipelines.
+This project assumes that you have a Github self-hosted runner running on your Kubernetes cluster that will have the necessary rights to perform operations on the Kubernetes API.
 <br/>
 
 ## Usage of available composite actions:
@@ -23,7 +24,7 @@ Look for for the latest version available on the [Releases](https://github.com/j
 ```
 ### 2. Deploy Helm chart to Kubernetes  
 ```yaml
-  # Add Helm repository, update, dry-run and install
+  # Add Helm repository, update repository, dry-run and install
   - name: Helm Deploy to Kubernetes
     uses: julanu/composite-actions/helm-deploy@latest
     with:
@@ -32,4 +33,7 @@ Look for for the latest version available on the [Releases](https://github.com/j
       registry_name: bitnami
       namespace: testing
       chart_version: 4.1.14
+      helm_values_file: values.yaml
+      values_overrides: ""
+      
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,4 @@ Look for for the latest version available on the [Releases](https://github.com/j
       namespace: testing
       chart_version: 4.1.14
       helm_values_file: values.yaml
-      values_overrides: ""
-      
 ```

--- a/helm-deploy/action.yml
+++ b/helm-deploy/action.yml
@@ -6,6 +6,11 @@ inputs:
     description: "Name for the Helm chart to be installed"
     default: ${{ github.event.repository.name }}
 
+  release_name:
+    required: true
+    description: "Name for your Helm release"
+    default: "my-chart"
+
   registry_url:
     required: true
     description: "Registry to the Helm repository hosting the chart"
@@ -45,12 +50,12 @@ runs:
     - name: Dry-Run Helm Chart for Microservice
       shell: bash
       run: |
-        helm install --dry-run --debug ${{ inputs.registry_name }}/${{ inputs.chart_name }} --version ${{ inputs.chart_version }} -n ${{ inputs.namespace }}
+        helm install --dry-run ${{ inputs.release_name }} ${{ inputs.registry_name }}/${{ inputs.chart_name }} --version ${{ inputs.chart_version }} -n ${{ inputs.namespace }}
 
     - name: Upgrade the Helm release w/ atomic
       shell: bash
       run: |
-        helm upgrade --install ${{ inputs.registry_name }}/${{ inputs.chart_name }} --version ${{ inputs.chart_version }} --atomic --cleanup-on-fail --timeout 600s -n ${{ inputs.namespace }}
+        helm upgrade --install ${{ inputs.release_name }} ${{ inputs.registry_name }}/${{ inputs.chart_name }} --version ${{ inputs.chart_version }} --atomic --cleanup-on-fail --timeout 600s -n ${{ inputs.namespace }}
 
     - name: View state of resources
       shell: bash

--- a/helm-deploy/action.yml
+++ b/helm-deploy/action.yml
@@ -80,7 +80,7 @@ runs:
       if: ${{ inputs.helm_values_file != null }}
       shell: bash
       run: |
-        helm upgrade -f ${{ inputs.helm_values_file }}--install ${{ inputs.release_name }} ${{ inputs.registry_name }}/${{ inputs.chart_name }} --version ${{ inputs.chart_version }} --atomic --cleanup-on-fail --timeout 600s -n ${{ inputs.namespace }}
+        helm upgrade -f ${{ inputs.helm_values_file }} --install ${{ inputs.release_name }} ${{ inputs.registry_name }}/${{ inputs.chart_name }} --version ${{ inputs.chart_version }} --atomic --cleanup-on-fail --timeout 600s -n ${{ inputs.namespace }}
       ###
 
     - name: View state of resources

--- a/helm-deploy/action.yml
+++ b/helm-deploy/action.yml
@@ -1,8 +1,5 @@
 name: "Deploy Helm Chart to Kubernetes"
 
-# ToDo Add namespace overrides
-# ToDo Add override arguments to install
-# ToDo Test overrides and values
 inputs:
   chart_name:
     required: true
@@ -37,7 +34,7 @@ inputs:
 
   values_overrides:
     required: false
-    description: ""
+    description: "Override values for your Helm install"
 
 
 runs:
@@ -77,13 +74,13 @@ runs:
       if: ${{ inputs.helm_values_file != null }}
       shell: bash
       run: |
-        helm install --dry-run ${{ inputs.release_name }} ${{ inputs.registry_name }}/${{ inputs.chart_name }} --version ${{ inputs.chart_version }} -n ${{ inputs.namespace }}
+        helm install -f ${{ inputs.helm_values_file }} --dry-run ${{ inputs.release_name }} ${{ inputs.registry_name }}/${{ inputs.chart_name }} --version ${{ inputs.chart_version }} -n ${{ inputs.namespace }}
 
     - name: Upgrade the Helm release w/ atomic & values.yaml file
       if: ${{ inputs.helm_values_file != null }}
       shell: bash
       run: |
-        helm upgrade --install ${{ inputs.release_name }} ${{ inputs.registry_name }}/${{ inputs.chart_name }} --version ${{ inputs.chart_version }} --atomic --cleanup-on-fail --timeout 600s -n ${{ inputs.namespace }}
+        helm upgrade -f ${{ inputs.helm_values_file }}--install ${{ inputs.release_name }} ${{ inputs.registry_name }}/${{ inputs.chart_name }} --version ${{ inputs.chart_version }} --atomic --cleanup-on-fail --timeout 600s -n ${{ inputs.namespace }}
       ###
 
     - name: View state of resources

--- a/helm-deploy/action.yml
+++ b/helm-deploy/action.yml
@@ -1,5 +1,8 @@
 name: "Deploy Helm Chart to Kubernetes"
 
+# ToDo Add namespace overrides
+# ToDo Add override arguments to install
+# ToDo Test overrides and values
 inputs:
   chart_name:
     required: true
@@ -28,6 +31,13 @@ inputs:
     description: "Version for the Helm chart. (default: 0.1.0)"
     default: 0.1.0
 
+  helm_values_file:
+    required: false
+    description: "Relative path to the values.yaml file for the Helm chart"
+
+  values_overrides:
+    required: false
+    description: ""
 
 
 runs:
@@ -47,15 +57,34 @@ runs:
       shell: bash
       run: helm repo update
 
+      ###
+      ### Install without values file -  Due to the limitations of Github Actions
     - name: Dry-Run Helm Chart for Microservice
+      if: ${{ inputs.helm_values_file == null }}
       shell: bash
       run: |
         helm install --dry-run ${{ inputs.release_name }} ${{ inputs.registry_name }}/${{ inputs.chart_name }} --version ${{ inputs.chart_version }} -n ${{ inputs.namespace }}
 
     - name: Upgrade the Helm release w/ atomic
+      if: ${{ inputs.helm_values_file == null }}
       shell: bash
       run: |
         helm upgrade --install ${{ inputs.release_name }} ${{ inputs.registry_name }}/${{ inputs.chart_name }} --version ${{ inputs.chart_version }} --atomic --cleanup-on-fail --timeout 600s -n ${{ inputs.namespace }}
+      ###
+
+      ### Install with values file -  Due to the limitations of Github Actions
+    - name: Dry-Run Helm Chart for Microservice w/ values.yaml file
+      if: ${{ inputs.helm_values_file != null }}
+      shell: bash
+      run: |
+        helm install --dry-run ${{ inputs.release_name }} ${{ inputs.registry_name }}/${{ inputs.chart_name }} --version ${{ inputs.chart_version }} -n ${{ inputs.namespace }}
+
+    - name: Upgrade the Helm release w/ atomic & values.yaml file
+      if: ${{ inputs.helm_values_file != null }}
+      shell: bash
+      run: |
+        helm upgrade --install ${{ inputs.release_name }} ${{ inputs.registry_name }}/${{ inputs.chart_name }} --version ${{ inputs.chart_version }} --atomic --cleanup-on-fail --timeout 600s -n ${{ inputs.namespace }}
+      ###
 
     - name: View state of resources
       shell: bash

--- a/helm-deploy/action.yml
+++ b/helm-deploy/action.yml
@@ -1,0 +1,57 @@
+name: "Deploy Helm Chart to Kubernetes"
+
+inputs:
+  chart_name:
+    required: true
+    description: "Name for the Helm chart to be installed"
+    default: ${{ github.event.repository.name }}
+
+  registry_url:
+    required: true
+    description: "Registry to the Helm repository hosting the chart"
+
+  registry_name:
+    required: true
+    description: "Name for the Helm repository holding your charts"
+
+  namespace:
+    required: true
+    description: "Namespace for the release to be installed"
+
+  chart_version:
+    required: true
+    description: "Version for the Helm chart. (default: 0.1.0)"
+    default: 0.1.0
+
+
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+          fetch-depth: 0
+
+    - name: Add Helm Repository
+      shell: bash
+      run: helm repo add ${{ inputs.registry_name }} ${{ inputs.registry_url }}
+
+    - name: Update Helm Repository
+      shell: bash
+      run: helm repo update
+
+    - name: Dry-Run Helm Chart for Microservice
+      shell: bash
+      run: |
+        helm install --dry-run --debug ${{ inputs.registry_name }} ${{ inputs.chart_name }} --version ${{ inputs.chart_version }} -n ${{ inputs.namespace }}
+
+    - name: Upgrade the Helm release w/ atomic
+      shell: bash
+      run: |
+        helm upgrade --install ${{ inputs.registry_name }} ${{ inputs.chart_name }} --version ${{ inputs.chart_version }} --atomic --cleanup-on-fail --timeout 600s -n ${{ inputs.namespace }}
+
+    - name: View state of resources
+      shell: bash
+      run: kubectl get all,secret -n ${{ inputs.namespace }}

--- a/helm-deploy/action.yml
+++ b/helm-deploy/action.yml
@@ -32,10 +32,6 @@ inputs:
     required: false
     description: "Relative path to the values.yaml file for the Helm chart"
 
-  values_overrides:
-    required: false
-    description: "Override values for your Helm install"
-
 
 runs:
   using: "composite"

--- a/helm-deploy/action.yml
+++ b/helm-deploy/action.yml
@@ -45,12 +45,12 @@ runs:
     - name: Dry-Run Helm Chart for Microservice
       shell: bash
       run: |
-        helm install --dry-run --debug ${{ inputs.registry_name }} ${{ inputs.chart_name }} --version ${{ inputs.chart_version }} -n ${{ inputs.namespace }}
+        helm install --dry-run --debug ${{ inputs.registry_name }}/${{ inputs.chart_name }} --version ${{ inputs.chart_version }} -n ${{ inputs.namespace }}
 
     - name: Upgrade the Helm release w/ atomic
       shell: bash
       run: |
-        helm upgrade --install ${{ inputs.registry_name }} ${{ inputs.chart_name }} --version ${{ inputs.chart_version }} --atomic --cleanup-on-fail --timeout 600s -n ${{ inputs.namespace }}
+        helm upgrade --install ${{ inputs.registry_name }}/${{ inputs.chart_name }} --version ${{ inputs.chart_version }} --atomic --cleanup-on-fail --timeout 600s -n ${{ inputs.namespace }}
 
     - name: View state of resources
       shell: bash


### PR DESCRIPTION
* Update README with usage of the new composite-actions
* Slight update to documentation
* Add composite-action for deploying a Helm chart to A Kubernetes cluster, will always do a dry-run before installing the chart
* Supports: 
  - Values file relative path
  - Chart version
  - Namespace for installation
  - Registry URL and name
  - Release name